### PR TITLE
Fixed issue with labels in release note CI

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -56,18 +56,17 @@ jobs:
 
       - uses: gittools/actions/gitreleasemanager/create@v0.9.9
         name: Create/Update GitHub Release ${{ steps.gitversion.outputs.majorMinorPatch }}
-        continue-on-error: true
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: 'corgibytes'
-          repository: 'freshli'
+          repository: 'freshli-lib'
           milestone: 'v${{ steps.gitversion.outputs.majorMinorPatch }}' 
 
       # This will generate the change log for all the GitHub Releases, feature
       # is not included in the GitReleaseManager action yet.
       - name: Generate Change Log
         run: |
-          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o 'corgibytes' -r 'freshli' -f 'CHANGELOG.md'
+          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o 'corgibytes' -r 'freshli-lib' -f 'CHANGELOG.md'
           cat CHANGELOG.md
 
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,29 @@
+## v0.4.0
+
+
+As part of this release we had [4 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
+Goals for this milestone:
+
+- Common Freshli dependency interface.
+- Support parsing multiple manifests but specifically focusing on .NET for this release.
+- Beta version of NuGet package.
+- Fail build if metrics like CodeClimate, Coverage, etc, are worse then previous build.
+
+__DevOps__
+
+- [__#277__](https://github.com/corgibytes/freshli-lib/pull/277) Add nuspec information
+- [__#268__](https://github.com/corgibytes/freshli-lib/issues/268) Version not correctly incremented when merging tag from release to main
+- [__#261__](https://github.com/corgibytes/freshli-lib/pull/261) Sets up minimal rename for NuGet push
+
+__Dependencies__
+
+- [__#260__](https://github.com/corgibytes/freshli-lib/pull/260) Bump DotNetEnv from 2.1.0 to 2.1.1
+
+
 ## v0.3.0
 
 
-As part of this release we had [4 issues](https://github.com/corgibytes/freshli/milestone/4?closed=1) closed.
+As part of this release we had [8 issues](https://github.com/corgibytes/freshli-lib/milestone/4?closed=1) closed.
 
 Goals for this milestone:
 
@@ -10,11 +32,24 @@ Goals for this milestone:
 - Clean-up of the ReadMe.
 - Basic support for Ruby, .NET, Python, Perl, and PHP.
 
+__Bug__
+
+- [__#258__](https://github.com/corgibytes/freshli-lib/pull/258) Ignores PHP dependencies for test projects
+
+__DevOps__
+
+- [__#241__](https://github.com/corgibytes/freshli-lib/issues/241) Auto generate change log and GitHub releases
+
+__Documentation__
+
+- [__#242__](https://github.com/corgibytes/freshli-lib/issues/242) Clean-up ReadMe for v0.3.0 release.
+- [__#225__](https://github.com/corgibytes/freshli-lib/issues/225) Update Jupyter Notebook Documentation
+
 __Enhancements__
 
-- [__#239__](https://github.com/corgibytes/freshli/pull/239) Deploys Alpha Packages to Github Packages
-- [__#238__](https://github.com/corgibytes/freshli/pull/238) Sets VSCode container development
-- [__#228__](https://github.com/corgibytes/freshli/issues/228) Auto-magically calculate version number
-- [__#4__](https://github.com/corgibytes/freshli/issues/4) Add support for NuGet (specific to using Freshli.Core)
+- [__#239__](https://github.com/corgibytes/freshli-lib/pull/239) Deploys Alpha Packages to Github Packages
+- [__#238__](https://github.com/corgibytes/freshli-lib/pull/238) Sets VSCode container development
+- [__#228__](https://github.com/corgibytes/freshli-lib/issues/228) Auto-magically calculate version number
+- [__#4__](https://github.com/corgibytes/freshli-lib/issues/4) Add support for NuGet (specific to using Freshli.Core)
 
 

--- a/GitReleaseManager.yaml
+++ b/GitReleaseManager.yaml
@@ -1,0 +1,28 @@
+issue-labels-include:
+  - bug
+  - dev-ops
+  - dependencies
+  - documentation
+  - enhancement
+
+issue-labels-alias:
+  - name: bug
+    header: Bug
+    plural: Bugs
+
+  - name: dev-ops
+    header: DevOps
+    plural: DevOps
+
+  - name: dependencies
+    header: Dependencies
+    plural: Dependencies
+
+  - name: documentation
+    header: Documentation
+    plural: Documentation
+    
+  - name: enhancement
+    header: Enhancement
+    plural: Enhancements
+  


### PR DESCRIPTION
Fixes #266.  Also updated the release notes CI to use `freshli-lib` repo instead of `freshli`.

Note: While testing this fix I regenerated the [v0.3.0](https://github.com/corgibytes/freshli-lib/releases/tag/v0.3.0) text and created the [v0.4.0](https://github.com/corgibytes/freshli-lib/releases/tag/untagged-4fd8dfc9838018f9d6ae) draft release.