### PR TITLE
Moves CodeClimate links to a publicly accessible open-source account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.4.0
 
 
-As part of this release we had [7 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
+As part of this release we had [8 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
 Goals for this milestone:
 
 - Common Freshli dependency interface.
@@ -11,6 +11,7 @@ Goals for this milestone:
 
 __DevOps__
 
+- [__#283__](https://github.com/corgibytes/freshli-lib/issues/283) Remove old Dependabot config
 - [__#277__](https://github.com/corgibytes/freshli-lib/pull/277) Add nuspec information
 - [__#268__](https://github.com/corgibytes/freshli-lib/issues/268) Version not correctly incremented when merging tag from release to main
 - [__#261__](https://github.com/corgibytes/freshli-lib/pull/261) Sets up minimal rename for NuGet push

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![.NET Core](https://github.com/corgibytes/freshli/workflows/.NET%20Core/badge.svg)](https://github.com/corgibytes/freshli/actions?query=workflow%3A%22.NET+Core%22)
 [![Docker Image CI](https://github.com/corgibytes/freshli/workflows/Docker%20Image%20CI/badge.svg)](https://github.com/corgibytes/freshli/actions?query=workflow%3A%22Docker+Image+CI%22)
 [![EditorConfig Lint](https://github.com/corgibytes/freshli/workflows/EditorConfig%20Lint/badge.svg)](https://github.com/corgibytes/freshli/actions?query=workflow%3A%22EditorConfig+Lint%22)
-[![Maintainability](https://api.codeclimate.com/v1/badges/d808370d214bbda62e58/maintainability)](https://codeclimate.com/repos/601c1f18f9414200c900094b/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/d808370d214bbda62e58/test_coverage)](https://codeclimate.com/repos/601c1f18f9414200c900094b/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/4d7b974eedea679e6b03/maintainability)](https://codeclimate.com/github/corgibytes/freshli-lib/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/4d7b974eedea679e6b03/test_coverage)](https://codeclimate.com/github/corgibytes/freshli-lib/test_coverage)
 
 # freshli
 A tool for collecting historical metrics about a project's dependencies


### PR DESCRIPTION
The secret used by GitHub Actions to send code coverage has also been updated to point to the new location.