### PR TITLE
Solve `Some checks haven't completed yet` issue caused by use of `git-auto-commit-action`

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0 # Required for GitVersion
           ref: ${{ github.head_ref }} # Required for Git Auto Commit
-        
+
       # Require .NET 5 for GitVersion and .NET 3 for GitRelesaseManager
       - name: Setup .NET Core 5 (GitVersion)
         uses: actions/setup-dotnet@v1
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.0.x
-      
+
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.9
         with:
@@ -48,7 +48,7 @@ jobs:
         id: gitversion
         with:
           useConfigFile: true
-      
+
       - uses: gittools/actions/gitreleasemanager/setup@v0.9.9
         name: Install GitReleaseManager
         with:
@@ -60,7 +60,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           owner: 'corgibytes'
           repository: 'freshli-lib'
-          milestone: 'v${{ steps.gitversion.outputs.majorMinorPatch }}' 
+          milestone: 'v${{ steps.gitversion.outputs.majorMinorPatch }}'
 
       # This will generate the change log for all the GitHub Releases, feature
       # is not included in the GitReleaseManager action yet.
@@ -72,6 +72,6 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         name: Commit Change Log and if it Changed
         with:
-          commit_message: Committing auto generated change log.
+          commit_message: Committing auto generated change log. [skip ci]
           file_pattern: CHANGELOG.md
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           fetch-depth: 0 # Required for GitVersion
           ref: ${{ github.head_ref }} # Required for Git Auto Commit
 
@@ -66,12 +67,14 @@ jobs:
       # is not included in the GitReleaseManager action yet.
       - name: Generate Change Log
         run: |
-          dotnet-gitreleasemanager export --token ${{ secrets.GITHUB_TOKEN }} -o 'corgibytes' -r 'freshli-lib' -f 'CHANGELOG.md'
+          dotnet-gitreleasemanager export --token ${{ secrets.PERSONAL_ACCESS_TOKEN }} -o 'corgibytes' -r 'freshli-lib' -f 'CHANGELOG.md'
           cat CHANGELOG.md
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         name: Commit Change Log and if it Changed
         with:
-          commit_message: Committing auto generated change log. [skip ci]
+          commit_message: Committing auto generated change log.
           file_pattern: CHANGELOG.md
+          commit_user_name: M. Scott Ford (as bot)
+          commit_user_email: scott@corgibytes.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.4.0
 
 
-As part of this release we had [7 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
+As part of this release we had [8 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
 Goals for this milestone:
 
 - Common Freshli dependency interface.
@@ -11,6 +11,7 @@ Goals for this milestone:
 
 __DevOps__
 
+- [__#283__](https://github.com/corgibytes/freshli-lib/issues/283) Remove old Dependabot config
 - [__#277__](https://github.com/corgibytes/freshli-lib/pull/277) Add nuspec information
 - [__#268__](https://github.com/corgibytes/freshli-lib/issues/268) Version not correctly incremented when merging tag from release to main
 - [__#261__](https://github.com/corgibytes/freshli-lib/pull/261) Sets up minimal rename for NuGet push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.4.0
 
 
-As part of this release we had [8 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
+As part of this release we had [7 issues](https://github.com/corgibytes/freshli-lib/milestone/5?closed=1) closed.
 Goals for this milestone:
 
 - Common Freshli dependency interface.
@@ -11,7 +11,6 @@ Goals for this milestone:
 
 __DevOps__
 
-- [__#283__](https://github.com/corgibytes/freshli-lib/issues/283) Remove old Dependabot config
 - [__#277__](https://github.com/corgibytes/freshli-lib/pull/277) Add nuspec information
 - [__#268__](https://github.com/corgibytes/freshli-lib/issues/268) Version not correctly incremented when merging tag from release to main
 - [__#261__](https://github.com/corgibytes/freshli-lib/pull/261) Sets up minimal rename for NuGet push


### PR DESCRIPTION
GitHub Actions are running on the commit that updates the changelog is added. This is causing some strange issues which appear to put a pull request in a strange state if there are no commits that come after the commit that modifies the changelog. Disabling the CI running on these changes _should_ do the trick.

Here's the strange state that the pull request is getting into:
![image](https://user-images.githubusercontent.com/21340/111880674-479b1900-8983-11eb-9407-7948714e81e5.png)

Here's the checks that were run on the changelog commit:
![image](https://user-images.githubusercontent.com/21340/111880697-600b3380-8983-11eb-8ad6-7635bdbcc274.png)

And here are the checks that ran on the commit that triggered the creation of the changelog:
![image](https://user-images.githubusercontent.com/21340/111880720-7fa25c00-8983-11eb-9278-156ca927e41d.png)

Those screenshots were taken shortly after the creation of #286. This was also observed on #243, but the pull request is no longer in that state because another commit has been added.