### PR TITLE
Only generate release notes on push and not PR

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - 'main'
       - 'release*'
-  pull_request:
-    branches:
-      - 'main'
-      - 'release*'
 
 jobs:
   release_notes:


### PR DESCRIPTION
Fixes #293.  Might also have to make remove the release note generation from the branch protection but not sure yet.