### PR TITLE
Don't submit the Code Climate test results on PRs

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -46,7 +46,7 @@ jobs:
         run: dotnet build --configuration Release
     
       - name: Run Tests
-        run: dontnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
+        run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
 
       # Only submit the test results on Code Climate on push.  When a dependabot PR
       # is created the submit to Code Climate will fail as the TEST_REPORTER_ID is not

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -45,13 +45,21 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release
     
-      - name: Test, Generate Code Coverage  
-        if: ${{ !env.ACT }}
+      - name: Run Tests
+        run: dontnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
+
+      # Only submit the test results on Code Climate on push.  When a dependabot PR
+      # is created the submit to Code Climate will fail as the TEST_REPORTER_ID is not
+      # available.
+      #
+      #  https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      #
+      - name: Submit Test Results to Code Climate
+        if: ${{ !env.ACT && github.event_name == 'push' }}
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.TEST_REPORTER_ID }}
         with:
-          coverageCommand: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
           coverageLocations: |
             ${{github.workspace}}/Corgibytes.Freshli.Lib.Test/coverage.info:lcov
 

--- a/Corgibytes.Freshli.sln
+++ b/Corgibytes.Freshli.sln
@@ -5,6 +5,19 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corgibytes.Freshli", "Corgi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corgibytes.Freshli.Test", "Corgibytes.Freshli.Lib.Test\Corgibytes.Freshli.Lib.Test.csproj", "{7C5BE77F-B9FA-495A-828C-ABA44F6536C6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{C2E53355-4A4C-4E25-9DE1-265AD73373FD}"
+ProjectSection(SolutionItems) = preProject
+	.github\dependabot.yml = .github\dependabot.yml
+EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{EEEC1A43-207D-4448-8F63-31D4820DBD65}"
+ProjectSection(SolutionItems) = preProject
+	.github\workflows\cla.yml = .github\workflows\cla.yml
+	.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
+	.github\workflows\eclint.yml = .github\workflows\eclint.yml
+	.github\workflows\release-notes.yml = .github\workflows\release-notes.yml
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -19,5 +32,8 @@ Global
 		{7C5BE77F-B9FA-495A-828C-ABA44F6536C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C5BE77F-B9FA-495A-828C-ABA44F6536C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C5BE77F-B9FA-495A-828C-ABA44F6536C6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EEEC1A43-207D-4448-8F63-31D4820DBD65} = {C2E53355-4A4C-4E25-9DE1-265AD73373FD}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Depdendabot does not allow GitHub secrets to be used so submitting the test results will Code Climate will fail on protected branches.

 https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

As a workaround I'm skipping submitting the test results to Code Climate on a PR.  Instead they are only submitted to Code Climate on a push.  Hard to fully test this fix until some new Dependabot PRs some in and this PR is merged.