### PR TITLE
Published Beta/Prod packages to NuGet (#265)

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -3,6 +3,7 @@ name: .NET Core
 on:
   push:
     branches: [ main, release* ]
+    tags: '*'
   pull_request:
     branches: [ main, release* ]
 
@@ -64,9 +65,13 @@ jobs:
             ${{github.workspace}}/Corgibytes.Freshli.Lib.Test/coverage.info:lcov
 
       - name: Package
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || startsWith(github.ref, 'refs/tags/')
         run: dotnet pack -c Release
 
       - name: Publish Alpha Package to Github Packages
         if: github.event_name == 'push'
         run: dotnet nuget push ./Corgibytes.Freshli.Lib/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate -n true -s https://nuget.pkg.github.com/corgibytes/index.json
+
+      - name: Publish Beta/Production Package to NuGet
+        if: github.event_name == 'push' || startsWith(github.ref, 'refs/tags/')
+        run: dotnet nuget push ./Corgibytes.Freshli.Lib/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate -n true -s https://api.nuget.org/v3/index.json

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -3,7 +3,7 @@ name: .NET Core
 on:
   push:
     branches: [ main, release* ]
-    tags: '*'
+    tags: 'v*'
   pull_request:
     branches: [ main, release* ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -446,3 +446,6 @@ Freshli.Test/coverage.info
 # https://github.com/nektos/act
 act.exe
 act/
+
+# Ignore test coverage file
+Corgibytes.Freshli.Lib.Test/coverage.info


### PR DESCRIPTION
This PR publishes any pushed tags onto the Corgibytes NuGet organization (https://www.nuget.org/profiles/corgibytes).

Depending on whether the package includes prerelease information, it will indicate being a pre-release, and won't be available as a standard package.
![image](https://user-images.githubusercontent.com/564106/117741659-f82dd800-b1d0-11eb-9c74-ddfbe889df3c.png)