### PR TITLE
Fix a bug in CI where alpha builds where getting published to Nuget.org.

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build
         run: dotnet build --configuration Release
-    
+
       - name: Run Tests
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov
 
@@ -95,5 +95,5 @@ jobs:
         run: dotnet nuget push ./Corgibytes.Freshli.Lib/bin/Release/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} --skip-duplicate -n true -s https://nuget.pkg.github.com/corgibytes/index.json
 
       - name: Publish Beta/Production Package to NuGet
-        if: github.event_name == 'push' || startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: dotnet nuget push ./Corgibytes.Freshli.Lib/bin/Release/*.nupkg -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate -n true -s https://api.nuget.org/v3/index.json


### PR DESCRIPTION
Fixes #340.  Now only beta and production releases are published to Nuget.org.  These are releases that have a tag.