### PR TITLE
Fix release notes CI when no issues are closed for milestone

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'release*'
-      - 'feature-fix-empty-milestone-ci-issue'
 
 jobs:
   release_notes:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -54,7 +54,6 @@ jobs:
       # If there are no closed issues generating the Github Release will fail because it raises an exception.
       # Work around this by checking for success or no closed issue errors.
       - name: "Create/Update GitHub Release ${{ steps.gitversion.outputs.majorMinorPatch }}"
-        if: ${{ github.event_name == 'push' }}
         run: |
           dotnet-gitreleasemanager create --owner corgibytes --repository freshli-cli --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
           cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release*'
+      - 'feature-fix-empty-milestone-ci-issue'
 
 jobs:
   release_notes:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -56,7 +56,7 @@ jobs:
       # Work around this by checking for success or no closed issue errors.
       - name: "Create/Update GitHub Release ${{ steps.gitversion.outputs.majorMinorPatch }}"
         run: |
-          dotnet-gitreleasemanager create --owner corgibytes --repository freshli-cli --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
+          dotnet-gitreleasemanager create --owner corgibytes --repository freshli-lib --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
           cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'
 
       # This will generate the change log for all the GitHub Releases, feature

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -51,13 +51,13 @@ jobs:
         with:
           versionSpec: '0.11.0'
 
-      - uses: gittools/actions/gitreleasemanager/create@v0.9.10
-        name: Create/Update GitHub Release ${{ steps.gitversion.outputs.majorMinorPatch }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          owner: 'corgibytes'
-          repository: 'freshli-lib'
-          milestone: 'v${{ steps.gitversion.outputs.majorMinorPatch }}'
+      # If there are no closed issues generating the Github Release will fail because it raises an exception.
+      # Work around this by checking for success or no closed issue errors.
+      - name: "Create/Update GitHub Release ${{ steps.gitversion.outputs.majorMinorPatch }}"
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          dotnet-gitreleasemanager create --owner corgibytes --repository freshli-cli --token ${{ secrets.GITHUB_TOKEN }} --milestone v${{ steps.gitversion.outputs.majorMinorPatch }} --logFilePath output.txt || true
+          cat output.txt | grep 'No closed issues have been found for milestone\|Drafted release is available at'
 
       # This will generate the change log for all the GitHub Releases, feature
       # is not included in the GitReleaseManager action yet.


### PR DESCRIPTION
If a milestone has no closed issue the [release notes](https://github.com/corgibytes/freshli-lib/actions/workflows/release-notes.yml) CI will raise an error as [this](https://github.com/corgibytes/freshli-lib/runs/3808207026?check_suite_focus=true) one did:

```
Run gittools/actions/gitreleasemanager/create@v0.9.10
Command: dotnet-gitreleasemanager create --owner corgibytes --repository freshli-lib --token *** --targetDirectory /home/runner/work/freshli-lib/freshli-lib --milestone v0.5.0
/opt/hostedtoolcache/GitReleaseManager.Tool/0.11.0/x64/dotnet-gitreleasemanager create --owner corgibytes --repository freshli-lib --token *** --targetDirectory /home/runner/work/freshli-lib/freshli-lib --milestone v0.5.0

   ____ ____  __  __
  / ___|  _ \|  \/  |
 | |  _| |_) | |\/| |
 | |_| |  _ <| |  | |
  \____|_| \_\_|  |_|
               0.11.0

Creating release...
Using GitHub as VCS Provider
[WRN] No valid version was found on Minimal Launch
[WRN] Unable to find tag for milestone, so commit count will be returned as zero
[FTL] No closed issues have been found for milestone v0.5.0, or all assigned issues are meant to be excluded from release notes, aborting creation of release.
System.InvalidOperationException: No closed issues have been found for milestone v0.5.0, or all assigned issues are meant to be excluded from release notes, aborting creation of release.
   at GitReleaseManager.Core.ReleaseNotesBuilder.BuildReleaseNotes()
   at GitReleaseManager.Core.GitHubProvider.CreateReleaseFromMilestone(String owner, String repository, String milestone, String releaseName, String targetCommitish, IList`1 assets, Boolean prerelease)
   at GitReleaseManager.Cli.Program.CreateReleaseAsync(CreateSubOptions subOptions) in C:\projects\gitreleasemanager\Source\GitReleaseManager.Cli\Program.cs:line 164
   at GitReleaseManager.Cli.Program.Main(String[] args) in C:\projects\gitreleasemanager\Source\GitReleaseManager.Cli\Program.cs:line 
```

This fix was borrowed from [freshli-cli](https://github.com/corgibytes/freshli-cli/blob/ea421cee05bf2a1919dcc577594ab7e698a60d1d/.github/workflows/ci.yml#L67) and checks the output message from the GitReleaseManager.  If the message is "no closed issues" or something similar it won't fail the build.