### PR TITLE
Force all Dependabot labels to be "dependencies" only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,16 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/" 
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"  
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
There is a known [issue](https://github.com/GitTools/GitReleaseManager/issues/90) with GitVersion that only one label is allowed.  If Dependabot is checking multiple package manager it will put two labels on the PR: "dependencies" and "<language/ecosystem>".  For example if the PR is for NuGet it will have the labels "dependencies" and ".net".

This PR forces all Dependabot PRs to only use the "dependencies" label.  We no longer have to manually remove the language label from Dependabot PRs.

More details on setting Dependabot labels can be found [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#labels).

Note: Not sure how to test this PR.  I think we will just have to merge it and see what happens but I'm open to suggestions.