### PR TITLE
Auto-merge Depndabot PR workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-approve/merge patch updates
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-20.04
+
+    # Only allo Dependabot PRs that update the patch version to be automerged.  Dependency updates for more than
+    # the patch require a manual review.
+    if: ${{ github.actor == 'dependabot[bot]' && ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}} }}
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-approve
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Auto merge Dependabot PRs that only update the patch version.  If the update is for the minor/major version it mush be manually merged.  Details on how the PR was created can be found at:

https://github.com/dependabot/fetch-metadata

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions

https://docs.github.com/en/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request

Note: Not sure how to test this PR.  I think we will just have to merge it and see what happens but I'm open to suggestions.