### PR TITLE
Adds Verify.DiffPlex to improve output

### DIFF
--- a/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
+++ b/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="DiffEngine" Version="8.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
         <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Verify.DiffPlex" Version="1.0.0" />
         <PackageReference Include="Verify.Xunit" Version="14.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/Corgibytes.Freshli.Lib.Test/Initializer.cs
+++ b/Corgibytes.Freshli.Lib.Test/Initializer.cs
@@ -3,7 +3,7 @@ using VerifyTests;
 
 namespace Corgibytes.Freshli.Lib.Test
 {
-    public class InitializeVerify
+    public class Initializer
     {
         [ModuleInitializer]
         public static void Initialize()

--- a/Corgibytes.Freshli.Lib.Test/Initializer.cs
+++ b/Corgibytes.Freshli.Lib.Test/Initializer.cs
@@ -1,0 +1,14 @@
+using System.Runtime.CompilerServices;
+using VerifyTests;
+
+namespace Corgibytes.Freshli.Lib.Test
+{
+    public class InitializeVerify
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {
+            VerifyDiffPlex.Initialize();
+        }
+    }
+}


### PR DESCRIPTION
Adds the Verify.DiffPlex package in attempt to improve the readability of Verify test output when there are differences between the received and verified files.

This was cherry-picked from a commit in #405.