### PR TITLE
Limits code coverage reporting to Linux

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Upload Coverage Files
         uses: actions/upload-artifact@v2
+        if: matrix.os == 'ubuntu-latest'
         with:
           name: "coverage-${{ matrix.config.os }}"
           path: "${{github.workspace}}/coverage-${{ matrix.config.os }}.info"


### PR DESCRIPTION
There are many different challenges present with publishing code coverage information to CodeClimate for all of the different platforms that are being built.

1. cc-test-reporter is not built for Windows
2. The GitHub Action that we're using
(paambaati/codeclimate-action@v3.0.0) does not support running the `format-coverage`, `sum-coverage` and `upload-coverage` commands as separate operations.
3. It is a non-trivial operation to correctly construct the environment variables that `cc-test-reporter` expects. See: https://github.com/paambaati/codeclimate-action/blob/c6ee9922e1b23fccfcc58a29c4c2072de52308a0/src/main.ts#L27-L44https://github.com/paambaati/codeclimate-action/blob/c6ee9922e1b23fccfcc58a29c4c2072de52308a0/src/main.ts#L27-L44

Hopefully, these issues will be overcome in the future, and we can publish more complete coverage data to CodeClimate. For now, we'll just publish the Linux specific data.