### PR TITLE
Dockerize development environment [fixes #304]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@
 
 ARG VARIANT=6.0
 FROM  mcr.microsoft.com/dotnet/sdk:${VARIANT}
+RUN apt-get update && apt-get install -y zip
+
 WORKDIR /freshli
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1.2
+
+ARG VARIANT=6.0
+FROM  mcr.microsoft.com/dotnet/sdk:${VARIANT}
+WORKDIR /freshli
+COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "3.9"
+services:
+  freshli:
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ version: "3.9"
 services:
   freshli:
     build: .
+    volumes:
+      - .:/freshli


### PR DESCRIPTION
See #304. The build failures have nothing to do with Docker and are fixed in #506.

I don't know if we need to do a better job with library caching, though; I'm open to suggestions (since I don't really know that well how the .NET environment handles all that in the first place).