### PR TITLE
Resolve build errors in test project

### DIFF
--- a/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
+++ b/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
@@ -17,7 +17,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="DiffEngine" Version="8.5.3" />
+        <PackageReference Include="DiffEngine" Version="9.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="Moq" Version="4.18.1" />
         <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />

--- a/Corgibytes.Freshli.Lib.Test/Initializer.cs
+++ b/Corgibytes.Freshli.Lib.Test/Initializer.cs
@@ -10,17 +10,13 @@ namespace Corgibytes.Freshli.Lib.Test
         {
             VerifyDiffPlex.Initialize();
 
-            VerifierSettings.ModifySerialization(settings =>
-            {
-                settings.DontScrubNumericIds();
-                settings.DontIgnoreEmptyCollections();
-                settings.DontScrubDateTimes();
-                settings.DontIgnoreFalse();
-                settings.MemberConverter<ScanResult, string>(
-                    r => r.Filename,
-                    (target, value) => value.Replace("\\", "/")
-                );
-            });
+            VerifierSettings.DontIgnoreEmptyCollections();
+            VerifierSettings.DontScrubDateTimes();
+            VerifierSettings.DontIgnoreFalse();
+            VerifierSettings.MemberConverter<ScanResult, string>(
+                r => r.Filename,
+                (target, value) => value.Replace("\\", "/")
+            );
         }
     }
 }


### PR DESCRIPTION
There were two issues causing build errors in the test project:
* A reference to DiffEngine 8.5.3, while an indirect reference through another dependency required 9.1.0
* Use of the [now removed](https://github.com/VerifyTests/Verify/pull/533) `VerifierSettings.ModifySerialization`

By upgrading the DiffEngine reference and updating the methods used to set up Verify, I am now able to build this project and run tests locally. However, some tests still fail.