### PR TITLE
Update all nuget dependencies

### DIFF
--- a/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
+++ b/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
-        <PackageReference Include="Verify.Xunit" Version="16.3.0" />
+        <PackageReference Include="Verify.Xunit" Version="17.10.2" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     </ItemGroup>

--- a/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
+++ b/Corgibytes.Freshli.Lib.Test/Corgibytes.Freshli.Lib.Test.csproj
@@ -17,12 +17,12 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="DiffEngine" Version="9.1.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-        <PackageReference Include="Moq" Version="4.18.1" />
+        <PackageReference Include="DiffEngine" Version="10.0.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+        <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="Verify.DiffPlex" Version="1.3.0" />
         <PackageReference Include="Verify.Xunit" Version="16.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     </ItemGroup>
 

--- a/Corgibytes.Freshli.Lib.Test/Initializer.cs
+++ b/Corgibytes.Freshli.Lib.Test/Initializer.cs
@@ -12,7 +12,6 @@ namespace Corgibytes.Freshli.Lib.Test
 
             VerifierSettings.DontIgnoreEmptyCollections();
             VerifierSettings.DontScrubDateTimes();
-            VerifierSettings.DontIgnoreFalse();
             VerifierSettings.MemberConverter<ScanResult, string>(
                 r => r.Filename,
                 (target, value) => value.Replace("\\", "/")

--- a/Corgibytes.Freshli.Lib.Test/Unit/Python/PythonVersionInfoTest.cs
+++ b/Corgibytes.Freshli.Lib.Test/Unit/Python/PythonVersionInfoTest.cs
@@ -12,7 +12,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         [Theory]
         [InlineData(
           "1!1",
-          1,
+          1L,
           "1", new long[] { 1 },
           null, null, false,
           null, null, false,
@@ -20,7 +20,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
             "10!1",
-            10,
+            10L,
             "1", new long[] { 1 },
             null, null, false,
             null, null, false,
@@ -28,7 +28,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "10!1.0",
-          10,
+          10L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
           null, null, false,
@@ -36,7 +36,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "20200101!1",
-          20200101,
+          20200101L,
           "1", new long[] { 1 },
           null, null, false,
           null, null, false,
@@ -44,7 +44,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "0.1",
-          0,
+          0L,
           "0.1", new long[] { 0, 1 },
           null, null, false,
           null, null, false,
@@ -52,7 +52,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "0.10",
-          0,
+          0L,
           "0.10", new long[] { 0, 10 },
           null, null, false,
           null, null, false,
@@ -60,7 +60,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "0.10.1",
-          0,
+          0L,
           "0.10.1", new long[] { 0, 10, 1 },
           null, null, false,
           null, null, false,
@@ -68,7 +68,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "1.0",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
           null, null, false,
@@ -76,7 +76,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "10.0",
-          0,
+          0L,
           "10.0", new long[] { 10, 0 },
           null, null, false,
           null, null, false,
@@ -84,7 +84,7 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "10.0.1.0",
-          0,
+          0L,
           "10.0.1.0", new long[] { 10, 0, 1, 0 },
           null, null, false,
           null, null, false,
@@ -92,179 +92,179 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         ]
         [InlineData(
           "1.0.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "1.0a1",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 1, true,
+          "a", 1L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0A1",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 1, true,
+          "a", 1L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0.1a1",
-          0,
+          0L,
           "1.0.1", new long[] { 1, 0, 1 },
-          "a", 1, true,
+          "a", 1L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0a2.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 2, true,
+          "a", 2L, true,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "1.0a12.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 12, true,
+          "a", 12L, true,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "1.0a12.post456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 12, true,
-          "post", 456, true,
+          "a", 12L, true,
+          "post", 456L, true,
           null, false)
         ]
         [InlineData(
           "1.0a12",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "a", 12, true,
+          "a", 12L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0b1.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "b", 1, true,
+          "b", 1L, true,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "1.0b2",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "b", 2, true,
+          "b", 2L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0b2.post345.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "b", 2, true,
-          "post", 345, true,
-          456, true)
+          "b", 2L, true,
+          "post", 345L, true,
+          456L, true)
         ]
         [InlineData(
           "1.0b2.post345",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "b", 2, true,
-          "post", 345, true,
+          "b", 2L, true,
+          "post", 345L, true,
           null, false)
         ]
         [InlineData(
           "1.0rc1",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "rc", 1, true,
+          "rc", 1L, true,
           null, null, false,
           null, false)
         ]
         [InlineData(
           "1.0rc1.dev456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "rc", 1, true,
+          "rc", 1L, true,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "1.0rc1.post456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
-          "rc", 1, true,
-          "post", 456, true,
+          "rc", 1L, true,
+          "post", 456L, true,
           null, false)
         ]
         [InlineData(
           "1.0.post456.dev34",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
-          "post", 456, true,
-          34, true)
+          "post", 456L, true,
+          34L, true)
         ]
         [InlineData(
           "1.0.post456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
-          "post", 456, true,
+          "post", 456L, true,
           null, false)
         ]
         [InlineData(
           "1.0.POST456",
-          0,
+          0L,
           "1.0", new long[] { 1, 0 },
           null, null, false,
-          "post", 456, true,
+          "post", 456L, true,
           null, false)
         ]
         [InlineData(
           "1.1.dev1",
-          0,
+          0L,
           "1.1", new long[] { 1, 1 },
           null, null, false,
           null, null, false,
-          1, true)
+          1L, true)
         ]
         [InlineData(
           "1.1.DEV1",
-          0,
+          0L,
           "1.1", new long[] { 1, 1 },
           null, null, false,
           null, null, false,
-          1, true)
+          1L, true)
         ]
         [InlineData(
           "2020!1.0.1.2.3.4b2.dev456",
-          2020,
+          2020L,
           "1.0.1.2.3.4", new long[] { 1, 0, 1, 2, 3, 4 },
-          "b", 2, true,
+          "b", 2L, true,
           null, null, false,
-          456, true)
+          456L, true)
         ]
         [InlineData(
           "2020!1.0.1.2.3.4.post345.dev456",
-          2020,
+          2020L,
           "1.0.1.2.3.4", new long[] { 1, 0, 1, 2, 3, 4 },
           null, null, false,
-          "post", 345, true,
-          456, true)
+          "post", 345L, true,
+          456L, true)
         ]
 
 
@@ -372,87 +372,87 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Python
         [Theory]
         [InlineData(
           "1.0.dev456",
-          PythonVersionInfo.SuffixType.Development,
+          (int)PythonVersionInfo.SuffixType.Development,
           null,
           null)
         ]
         [InlineData(
           "1.0a1",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.NoSuffix,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.NoSuffix,
           null)
         ]
         [InlineData(
           "1.0a2.dev456",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Development,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Development,
           null)
         ]
         [InlineData(
           "1.0a12.dev456",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Development,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Development,
           null)
         ]
         [InlineData(
           "1.0a12",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.NoSuffix,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.NoSuffix,
           null)
         ]
         [InlineData(
           "1.0b1.dev456",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Development,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Development,
           null)
         ]
         [InlineData(
           "1.0b2",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.NoSuffix,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.NoSuffix,
           null)
         ]
         [InlineData(
           "1.0b2.post345.dev456",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Post,
-          PythonVersionInfo.SuffixType.Development)
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Post,
+          (int)PythonVersionInfo.SuffixType.Development)
         ]
         [InlineData(
           "1.0b2.post345",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Post,
-          PythonVersionInfo.SuffixType.NoSuffix)
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Post,
+          (int)PythonVersionInfo.SuffixType.NoSuffix)
         ]
         [InlineData(
           "1.0rc1.dev456",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.Development,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.Development,
           null)
         ]
         [InlineData(
           "1.0rc1",
-          PythonVersionInfo.SuffixType.Pre,
-          PythonVersionInfo.SuffixType.NoSuffix,
+          (int)PythonVersionInfo.SuffixType.Pre,
+          (int)PythonVersionInfo.SuffixType.NoSuffix,
           null)
         ]
         [InlineData(
           "1.0",
-          PythonVersionInfo.SuffixType.NoSuffix,
+          (int)PythonVersionInfo.SuffixType.NoSuffix,
           null,
           null)
         ]
         [InlineData(
           "1.0.post456.dev34",
-          PythonVersionInfo.SuffixType.Post,
+          (int)PythonVersionInfo.SuffixType.Post,
           null,
-          PythonVersionInfo.SuffixType.Development)
+          (int)PythonVersionInfo.SuffixType.Development)
         ]
         [InlineData(
           "1.0.post456",
-          PythonVersionInfo.SuffixType.Post,
+          (int)PythonVersionInfo.SuffixType.Post,
           null,
-          PythonVersionInfo.SuffixType.NoSuffix)
+          (int)PythonVersionInfo.SuffixType.NoSuffix)
         ]
 
         public void SortPositionsAreCorrectlySet(

--- a/Corgibytes.Freshli.Lib.Test/Unit/SemVerVersionInfoTest.cs
+++ b/Corgibytes.Freshli.Lib.Test/Unit/SemVerVersionInfoTest.cs
@@ -7,33 +7,33 @@ namespace Corgibytes.Freshli.Lib.Test.Unit
     public class SemVerVersionInfoTest
     {
         [Theory]
-        [InlineData("1", 1, null, null, false, null, null)]
-        [InlineData("v3.6.0", 3, 6, 0, false, null, null)]
-        [InlineData("1.2", 1, 2, null, false, null, null)]
-        [InlineData("1.2.3", 1, 2, 3, false, null, null)]
-        [InlineData("1.2.3a1", 1, 2, 3, true, "a1", null)]
-        [InlineData("1.2.3-a1", 1, 2, 3, true, "a1", null)]
-        [InlineData("1.2.3a1+dev", 1, 2, 3, true, "a1", "dev")]
-        [InlineData("1.2.3-a1+dev", 1, 2, 3, true, "a1", "dev")]
-        [InlineData("1.0045", 1, 0045, null, false, null, null)]
-        [InlineData("1.0009", 1, 0009, null, false, null, null)]
-        [InlineData("1.301001_050", 1, 301001, 050, false, null, null)]
-        [InlineData("20110131120940", 20110131120940, null, null, false, null,
+        [InlineData("1", 1L, null, null, false, null, null)]
+        [InlineData("v3.6.0", 3L, 6L, 0L, false, null, null)]
+        [InlineData("1.2", 1L, 2L, null, false, null, null)]
+        [InlineData("1.2.3", 1L, 2L, 3L, false, null, null)]
+        [InlineData("1.2.3a1", 1L, 2L, 3L, true, "a1", null)]
+        [InlineData("1.2.3-a1", 1L, 2L, 3L, true, "a1", null)]
+        [InlineData("1.2.3a1+dev", 1L, 2L, 3L, true, "a1", "dev")]
+        [InlineData("1.2.3-a1+dev", 1L, 2L, 3L, true, "a1", "dev")]
+        [InlineData("1.0045", 1L, 0045L, null, false, null, null)]
+        [InlineData("1.0009", 1L, 0009L, null, false, null, null)]
+        [InlineData("1.301001_050", 1L, 301001L, 050L, false, null, null)]
+        [InlineData("20110131120940", 20110131120940L, null, null, false, null,
           null)]
-        [InlineData("2.20110131120940", 2, 20110131120940, null, false, null, null)]
-        [InlineData("2.0.20110131120940", 2, 0, 20110131120940, false, null, null)]
-        [InlineData("2.0.8.beta.20110131120940", 2, 0, 8, true,
+        [InlineData("2.20110131120940", 2L, 20110131120940L, null, false, null, null)]
+        [InlineData("2.0.20110131120940", 2L, 0L, 20110131120940L, false, null, null)]
+        [InlineData("2.0.8.beta.20110131120940", 2L, 0L, 8L, true,
           "beta.20110131120940", null)]
-        [InlineData("1.0.0-alpha", 1, 0, 0, true, "alpha", null)]
-        [InlineData("1.0.0-alpha.1", 1, 0, 0, true, "alpha.1", null)]
-        [InlineData("1.0.0-0.3.7", 1, 0, 0, true, "0.3.7", null)]
-        [InlineData("1.0.0-x.7.z.92", 1, 0, 0, true, "x.7.z.92", null)]
-        [InlineData("1.0.0-x-y-z.-", 1, 0, 0, true, "x-y-z.-", null)]
-        [InlineData("1.0.0-alpha+001", 1, 0, 0, true, "alpha", "001")]
-        [InlineData("1.0.0+20130313144700", 1, 0, 0, false, null, "20130313144700")]
-        [InlineData("1.0.0-beta+exp.sha.5114f85", 1, 0, 0, true, "beta",
+        [InlineData("1.0.0-alpha", 1L, 0L, 0L, true, "alpha", null)]
+        [InlineData("1.0.0-alpha.1", 1L, 0L, 0L, true, "alpha.1", null)]
+        [InlineData("1.0.0-0.3.7", 1L, 0L, 0L, true, "0.3.7", null)]
+        [InlineData("1.0.0-x.7.z.92", 1L, 0L, 0L, true, "x.7.z.92", null)]
+        [InlineData("1.0.0-x-y-z.-", 1L, 0L, 0L, true, "x-y-z.-", null)]
+        [InlineData("1.0.0-alpha+001", 1L, 0L, 0L, true, "alpha", "001")]
+        [InlineData("1.0.0+20130313144700", 1L, 0L, 0L, false, null, "20130313144700")]
+        [InlineData("1.0.0-beta+exp.sha.5114f85", 1L, 0L, 0L, true, "beta",
           "exp.sha.5114f85")]
-        [InlineData("1.0.0+21AF26D3--117B344092BD", 1, 0, 0, false, null,
+        [InlineData("1.0.0+21AF26D3--117B344092BD", 1L, 0L, 0L, false, null,
           "21AF26D3--117B344092BD")]
         public void VersionIsParsedIntoParts(
           string version,

--- a/Corgibytes.Freshli.Lib.Test/Unit/Util/VersionHelperTest.cs
+++ b/Corgibytes.Freshli.Lib.Test/Unit/Util/VersionHelperTest.cs
@@ -7,12 +7,12 @@ namespace Corgibytes.Freshli.Lib.Test.Unit.Util
     {
 
         [Theory]
-        [InlineData(1, 1, 0)]
-        [InlineData(100, 1, 1)]
-        [InlineData(1, 100, -1)]
+        [InlineData(1L, 1L, 0)]
+        [InlineData(100L, 1L, 1)]
+        [InlineData(1L, 100L, -1)]
         [InlineData(null, null, 0)]
-        [InlineData(1, null, 1)]
-        [InlineData(null, 1, -1)]
+        [InlineData(1L, null, 1)]
+        [InlineData(null, 1L, -1)]
 
         public void NumericValuesAreComparedCorrectly(
           long? firstValue,

--- a/Corgibytes.Freshli.Lib/Corgibytes.Freshli.Lib.csproj
+++ b/Corgibytes.Freshli.Lib/Corgibytes.Freshli.Lib.csproj
@@ -18,12 +18,12 @@
     <ItemGroup>
       <PackageReference Include="DotNetEnv" Version="2.3.0" />
       <PackageReference Include="Elasticsearch.Net" Version="7.13.2" />
-      <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+      <PackageReference Include="HtmlAgilityPack" Version="1.11.45" />
       <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
-      <PackageReference Include="NLog" Version="4.7.15" />
-      <PackageReference Include="NuGet.Protocol" Version="6.2.0" />
+      <PackageReference Include="NLog" Version="5.0.4" />
+      <PackageReference Include="NuGet.Protocol" Version="6.3.0" />
       <PackageReference Include="Polly" Version="7.2.3" />
-      <PackageReference Include="RestSharp" Version="106.15.0" />
+      <PackageReference Include="RestSharp" Version="108.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Corgibytes.Xunit.Extensions/Corgibytes.Xunit.Extensions.csproj
+++ b/Corgibytes.Xunit.Extensions/Corgibytes.Xunit.Extensions.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Requires more explicit types used in tests, possibly due to https://github.com/xunit/xunit/pull/2417. Note that we are intentionally not updating Elasticsearch to maintain compatibility with MetaCPAN.

My thinking is that we merge this, and then release a .NET 6 version of the NuGet package. I'm not sure on how the release process works; it looks like the prerelease action may be [failing due to incorrect versioning](https://github.com/corgibytes/freshli-lib/runs/8251441788?check_suite_focus=true) so any guidance on release would be appreciated.